### PR TITLE
加了角色搜索和下载的功能

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,12 @@
     </div>
     <div class="container"><textarea rows="15" class="input-box" value="" placeholder="请输入文本..."></textarea>
         <div class="options">
-            <div class="option"><span class="tag">角色</span> <select class="selector"></select></div>
+            <div class="option">
+                <span class="tag">角色</span>
+                <select class="selector"></select>
+                <input placeholder="必须和列表里的名字完全相同" size="12" id="character-search-box">
+                <button style="justify-content: center; display: block; margin: 0px auto; width: 15%;">搜索</button>
+            </div>
             <div class="option"><span class="tag">感情</span> <input type="range" min="0" max="1.5" step="0.1" value="0.6"
                     class="slide" name="noise"> <span class="param tag"></span></div>
             <div class="option"><span class="tag">音素长度</span> <input type="range" min="0" max="1.5" step="0.1"
@@ -49,6 +54,7 @@
             <audio controls class="player">
                 <source src="">
             </audio>
+            <button id="download-button" style="background-color: rgb(0, 134, 209); border: medium; border-radius: 8px; color: rgb(255, 255, 255); cursor: pointer; font-family: SmileySans; font-size: 1rem; height: 100%; margin-right: 20px; transition: 0.4s; width: 10%;">下载</button>
         </div>
         <div class="intro">
             <div class="intro-item">参数说明</div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import { handle } from './utils/proxy.js'
-import { createOptions, setParams, bindData, getVoice, forbidCheck } from './utils/index.js'
+import { createOptions, setParams, bindData, getVoice, forbidCheck, defineSearchButton, defineDownloadButton} from './utils/index.js'
 import dialog from './utils/dialog'
 import css from './assets/style/index.css'
 
@@ -36,3 +36,9 @@ dialog()
 document.querySelector('.produce').addEventListener('click', () => {
     getVoice()
 })
+
+// 搜索按钮定义
+defineSearchButton()
+
+// 下载按钮定义
+defineDownloadButton()

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -83,3 +83,31 @@ export const forbidCheck = () => {
     }
     check()
 }
+
+// 搜索按钮定义
+export const defineSearchButton = () => {
+    // 先设置value，然后触发 change event来更改全局变量（为什么要用一个全局变量而不是请求的时候读取几个框里的内容啊）
+    const searchButton = document.getElementById('button');
+    searchButton.addEventListener("click", function() {
+        const characterSelect = document.querySelectorAll('select.selector')[0];
+        characterSelect.value = document.getElementById('characterSearchBox').value;
+        const changeEvent = new Event("change");
+        characterSelect.dispatchEvent(changeEvent);
+    })
+}
+
+// 方便下载和自动命名
+export const defineDownloadButton = (url, name) => {
+    const button = document.getElementById("download-button");
+    button.addEventListener("click", function() {
+        // 如果没点过生成会自动生成并下载
+        document.querySelector('button.produce').click();
+        const downloadLink = document.createElement('a');
+        // {角色}：{文本}.{后缀}。文本先替换换行为空格，然后取前10个字符。
+        downloadLink.download=document.querySelectorAll('select.selector')[0].selectedOptions[0].value+'：'+document.querySelector('textarea.input-box').value.replaceAll('\n', ' ').slice(0, 10)+'.'+document.querySelectorAll('select.selector')[1].selectedOptions[0].value;
+        // 还没点生成、点了还没返回或者已经返回了都不会重复请求。还没生成点下载会先生成。
+        downloadLink.href=document.querySelector('audio.player').src;
+        downloadLink.click();
+    });
+    document.querySelector('div.btns').appendChild(button);
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -104,7 +104,7 @@ export const defineDownloadButton = (url, name) => {
         document.querySelector('button.produce').click();
         const downloadLink = document.createElement('a');
         // {角色}：{文本}.{后缀}。文本先替换换行为空格，然后取前10个字符。
-        downloadLink.download=document.querySelectorAll('select.selector')[0].selectedOptions[0].value+'：'+document.querySelector('textarea.input-box').value.replaceAll('\n', ' ').slice(0, 10)+'.'+document.querySelectorAll('select.selector')[1].selectedOptions[0].value;
+        downloadLink.download=document.querySelectorAll('select.selector')[0].selectedOptions[0].value+'：'+document.querySelector('textarea.input-box').value.replaceAll('\n', ' ').replaceAll('\r', ' ').slice(0, 10)+'.'+document.querySelectorAll('select.selector')[1].selectedOptions[0].value;
         // 还没点生成、点了还没返回或者已经返回了都不会重复请求。还没生成点下载会先生成。
         downloadLink.href=document.querySelector('audio.player').src;
         downloadLink.click();


### PR DESCRIPTION
我在用油猴插件加功能的时候发现只要控制台一出来就点不动网页了，还以为浏览器bug，原来还有forbidCheck这种操作

搜索功能可以把输入的角色名自动在列表里选出来。
下载功能会按照`{角色名}：{文本前10字}.{后缀}`下载。

代码在油猴里测试过，两个功能都正常（只在Bert-VITS2合成里测试，原版VITS合成没试）。但是我这里没有后端，没法测试直接加到网页里的成果。麻烦测试一下。